### PR TITLE
Adaptation for Visual C++ 2013

### DIFF
--- a/include/yas/detail/config/config.hpp
+++ b/include/yas/detail/config/config.hpp
@@ -38,8 +38,13 @@
 
 /***************************************************************************/
 
-#if __cplusplus < 201103L
+#if __cplusplus < 201103L && _MSC_VER < 1800
 #	error "C++11 or greater support is required"
+#endif
+
+#if _MSC_VER <= 1800
+#define constexpr 
+#define noexcept throw()
 #endif
 
 /***************************************************************************/

--- a/include/yas/detail/io/information.hpp
+++ b/include/yas/detail/io/information.hpp
@@ -65,8 +65,12 @@ union archive_header {
 		:as_char(c)
 	{}
 	archive_header(const std::uint8_t v, const std::uint8_t t, const std::uint8_t b, const std::uint8_t e)
-		:bits{v, t, b, e}
-	{}
+	{
+		bits.version = v;
+		bits.type = t;
+		bits.bits = b;
+		bits.endian = e;
+	}
 
 	struct {
 		std::uint8_t version:3; // version     : 0 ... 7

--- a/include/yas/serializers/binary/std/std_tuple_serializers.hpp
+++ b/include/yas/serializers/binary/std/std_tuple_serializers.hpp
@@ -133,7 +133,7 @@ namespace detail {
 
 /***************************************************************************/
 
-#if _MSC_VER >= 1700
+#if _MSC_VER == 1700
 YAS__BINARY__GENERATE_SAVE_SERIALIZE_STD_TUPLE_FUNCTIONS_VARIADIC(_VARIADIC_MAX)
 YAS__BINARY__GENERATE_LOAD_SERIALIZE_STD_TUPLE_FUNCTIONS_VARIADIC(_VARIADIC_MAX)
 #else

--- a/include/yas/serializers/json/std/std_tuple_serializers.hpp
+++ b/include/yas/serializers/json/std/std_tuple_serializers.hpp
@@ -130,7 +130,7 @@ namespace detail {
 
 /***************************************************************************/
 
-#if _MSC_VER >= 1700
+#if _MSC_VER == 1700
 YAS__JSON__GENERATE_SAVE_SERIALIZE_STD_TUPLE_FUNCTIONS_VARIADIC(_VARIADIC_MAX)
 YAS__JSON__GENERATE_LOAD_SERIALIZE_STD_TUPLE_FUNCTIONS_VARIADIC(_VARIADIC_MAX)
 #else

--- a/include/yas/serializers/text/std/std_tuple_serializers.hpp
+++ b/include/yas/serializers/text/std/std_tuple_serializers.hpp
@@ -130,7 +130,7 @@ namespace detail {
 
 /***************************************************************************/
 
-#if _MSC_VER >= 1700
+#if _MSC_VER == 1700
 YAS__TEXT__GENERATE_SAVE_SERIALIZE_STD_TUPLE_FUNCTIONS_VARIADIC(_VARIADIC_MAX)
 YAS__TEXT__GENERATE_LOAD_SERIALIZE_STD_TUPLE_FUNCTIONS_VARIADIC(_VARIADIC_MAX)
 #else


### PR DESCRIPTION
In Visual C++ 2013 __cplusplus == 199711 is still, but many of C++11 features are available, except of required `constexpr` and `nothrow`
