### PR TITLE
Fixed mem_ostream::get_shared_buffer()

### DIFF
--- a/include/yas/mem_streams.hpp
+++ b/include/yas/mem_streams.hpp
@@ -95,7 +95,7 @@ struct mem_ostream: private detail::noncopyable {
 		return size;
 	}
 
-	shared_buffer get_shared_buffer() const { return shared_buffer(beg, cur-beg); }
+	shared_buffer get_shared_buffer() const { return shared_buffer(buf.data, cur-beg); }
 	intrusive_buffer get_intrusive_buffer() const { return intrusive_buffer(beg, cur-beg); }
 
 private:


### PR DESCRIPTION
Creating  shared_buffer with shared data of mem_ostream::buf  instead of copying them into a new buffer.
