### PR TITLE
Add resize() and assign() functions into shared_buffer

### DIFF
--- a/include/yas/buffers.hpp
+++ b/include/yas/buffers.hpp
@@ -67,23 +67,15 @@ private:
 struct shared_buffer {
 	typedef std::shared_ptr<char> shared_array_type;
 
-	shared_buffer()
+	explicit shared_buffer(std::size_t size = 0)
 		:size(0)
-	{}
-	shared_buffer(std::size_t size)
-		:size(size)
 	{
-		if ( size ) {
-			data.reset(new char[size], &deleter);
-		}
+		resize(size);
 	}
 	shared_buffer(const void *ptr, std::size_t size)
-		:size(size)
+		:size(0)
 	{
-		if ( size ) {
-			data.reset(new char[size], &deleter);
-			std::memcpy(data.get(), ptr, size);
-		}
+		assign(ptr, size);
 	}
 	shared_buffer(const shared_array_type& buf, std::size_t size)
 		:size(size)
@@ -97,6 +89,22 @@ struct shared_buffer {
 	{
 		if ( size ) {
 			data = buf.data;
+		}
+	}
+
+	void resize(std::size_t new_size)
+	{
+		if ( new_size > size ) {
+			data.reset(new char[new_size], &deleter);
+		}
+		size = new_size;
+	}
+
+	void assign(const void *ptr, std::size_t size)
+	{
+		resize(size);
+		if ( size ) {
+			std::memcpy(data.get(), ptr, size);
 		}
 	}
 


### PR DESCRIPTION
Combined 2 shared_buffer constructors for default shared_buffer and pre-allocated shared_buffer into single constructor with default value of size=0

shared_buffer::resize() does not re-allocate data buffer if the buffer shrinks on resize.

shared_buffer::assign() allows to assign new data without buffer re-allocation if the new data size is not greater then previous.