### PR TITLE
Add default assign operators for shared_buffer

### DIFF
--- a/include/yas/buffers.hpp
+++ b/include/yas/buffers.hpp
@@ -97,6 +97,8 @@ struct shared_buffer {
 	{
 		buf.size = 0;
 	}
+	shared_buffer& operator=(const shared_buffer&) = default;
+	shared_buffer& operator=(shared_buffer&&) = default;
 
 	void resize(std::size_t new_size)
 	{


### PR DESCRIPTION
To fix Travis build, since shared_buffer move ctor deletes implicit assignment operator.

By the way I can't compile and run on my localhost `base` test used in Travis script. 