### PR TITLE
Add size_t to the list of unsigned number types

### DIFF
--- a/include/yas/detail/io/binary_streams.hpp
+++ b/include/yas/detail/io/binary_streams.hpp
@@ -136,7 +136,7 @@ struct binary_ostream {
 
     // for unsigned
     template<typename T>
-    void write(T v, YAS_ENABLE_IF_IS_ANY_OF(T, std::uint16_t, std::uint32_t, std::uint64_t)) {
+    void write(T v, YAS_ENABLE_IF_IS_ANY_OF(T, std::uint16_t, std::uint32_t, std::uint64_t, std::size_t)) {
         if ( F & yas::compacted ) {
             if ( v <= (1<<5) ) {
                 std::uint8_t ns = YAS_SCAST(std::uint8_t, v);


### PR DESCRIPTION
The specification is unclear about whether is_same<size_t, uint64_t> shall be true or not. On the latest macOS, it is not, thus it is unable to serialized size_t types without mentioning it explicitly.