### PR TITLE
Removed old include file in speed test

### DIFF
--- a/tests/speed/main.cpp
+++ b/tests/speed/main.cpp
@@ -42,7 +42,6 @@
 #include <yas/text_iarchive.hpp>
 #include <yas/text_oarchive.hpp>
 #include <yas/mem_streams.hpp>
-#include <yas/tools/hexdumper.hpp>
 
 #include <boost/program_options.hpp>
 


### PR DESCRIPTION
The hexdumper.hpp file was renamed but the old hex_dump was not used, so the include was removed.