### PR TITLE
Streamlined datatypes in binary_streams

### DIFF
--- a/include/yas/detail/io/binary_streams.hpp
+++ b/include/yas/detail/io/binary_streams.hpp
@@ -71,7 +71,7 @@ struct binary_ostream {
 
     // for signed
     template<typename T>
-    void write(T v, __YAS_ENABLE_IF_IS_ANY_OF(T, std::int16_t, std::int32_t, std::int64_t)) {
+    void write(T v, __YAS_ENABLE_IF_IS_SIGNED_INTEGER(T)) {
         __YAS_CONSTEXPR_IF ( F & yas::compacted ) {
             if ( v >= 0 ) {
                 typename std::make_unsigned<T>::type uv = v;
@@ -104,7 +104,7 @@ struct binary_ostream {
 
     // for unsigned
     template<typename T>
-    void write(T v, __YAS_ENABLE_IF_IS_ANY_OF(T, std::uint16_t, std::uint32_t, std::uint64_t)) {
+    void write(T v, __YAS_ENABLE_IF_IS_UNSIGNED_INTEGER(T)) {
         __YAS_CONSTEXPR_IF ( F & yas::compacted ) {
             if ( v >= (1u<<7) ) {
                 const std::uint8_t ns = storage_size(v);
@@ -133,19 +133,7 @@ private:
 
 private:
     template<typename T>
-    static constexpr std::uint8_t storage_size(const T &v, __YAS_ENABLE_IF_IS_ANY_OF(T, std::uint16_t)) {
-        return __YAS_SCAST(std::uint8_t, (v < (1u<<8 )) ? 1u : 2u);
-    }
-    template<typename T>
-    static constexpr std::uint8_t storage_size(const T &v, __YAS_ENABLE_IF_IS_ANY_OF(T, std::uint32_t)) {
-        return __YAS_SCAST(std::uint8_t,
-            (v < (1u<<16) )
-                ? ((v < (1u<<8 )) ? 1u : 2u)
-                : ((v < (1u<<24)) ? 3u : 4u)
-        );
-    }
-    template<typename T>
-    static constexpr std::uint8_t storage_size(const T &v, __YAS_ENABLE_IF_IS_ANY_OF(T, std::uint64_t)) {
+    static constexpr std::uint8_t storage_size(const T &v, __YAS_ENABLE_IF_IS_UNSIGNED_INTEGER(T)) {
         return __YAS_SCAST(std::uint8_t,
             (v < (1ull<<32))
                 ? (v < (1u<<16) )
@@ -193,7 +181,7 @@ struct binary_istream {
 
     // for signed
     template<typename T>
-    void read(T &v, __YAS_ENABLE_IF_IS_ANY_OF(T, std::int16_t, std::int32_t, std::int64_t)) {
+    void read(T &v, __YAS_ENABLE_IF_IS_SIGNED_INTEGER(T)) {
         __YAS_CONSTEXPR_IF ( F & yas::compacted ) {
             std::uint8_t ns = __YAS_SCAST(std::uint8_t, is.getch());
             const bool neg = __YAS_SCAST(bool, (ns >> 7) & 1u);
@@ -215,7 +203,7 @@ struct binary_istream {
 
     // for unsigned
     template<typename T>
-    void read(T &v, __YAS_ENABLE_IF_IS_ANY_OF(T, std::uint16_t, std::uint32_t, std::uint64_t)) {
+    void read(T &v, __YAS_ENABLE_IF_IS_UNSIGNED_INTEGER(T)) {
        __YAS_CONSTEXPR_IF ( F & yas::compacted ) {
             std::uint8_t ns = __YAS_SCAST(std::uint8_t, is.getch());
             const bool onebyte = __YAS_SCAST(bool, (ns >> 7) & 1u);

--- a/include/yas/detail/io/binary_streams.hpp
+++ b/include/yas/detail/io/binary_streams.hpp
@@ -133,7 +133,19 @@ private:
 
 private:
     template<typename T>
-    static constexpr std::uint8_t storage_size(const T &v, __YAS_ENABLE_IF_IS_UNSIGNED_INTEGER(T)) {
+    static constexpr std::uint8_t storage_size(const T &v, __YAS_ENABLE_IF_IS_16BIT(T)) {
+        return __YAS_SCAST(std::uint8_t, (v < (1u<<8 )) ? 1u : 2u);
+    }
+    template<typename T>
+    static constexpr std::uint8_t storage_size(const T &v, __YAS_ENABLE_IF_IS_32BIT(T)) {
+        return __YAS_SCAST(std::uint8_t,
+            (v < (1u<<16) )
+                ? ((v < (1u<<8 )) ? 1u : 2u)
+                : ((v < (1u<<24)) ? 3u : 4u)
+        );
+    }
+    template<typename T>
+    static constexpr std::uint8_t storage_size(const T &v, __YAS_ENABLE_IF_IS_64BIT(T)) {
         return __YAS_SCAST(std::uint8_t,
             (v < (1ull<<32))
                 ? (v < (1u<<16) )

--- a/include/yas/detail/io/endian_conv.hpp
+++ b/include/yas/detail/io/endian_conv.hpp
@@ -95,13 +95,13 @@ struct endian_converter<false> {
 template<>
 struct endian_converter<true> {
 	template<typename T>
-	static T bswap(const T &v, __YAS_ENABLE_IF_IS_ANY_OF(T, std::int16_t, std::uint16_t))
+	static T bswap(const T &v, __YAS_ENABLE_IF_IS_16BIT(T))
 	{ return __YAS_NETWORK_TO_LOCAL16(v); }
 	template<typename T>
-	static T bswap(const T &v, __YAS_ENABLE_IF_IS_ANY_OF(T, std::int32_t, std::uint32_t))
+	static T bswap(const T &v, __YAS_ENABLE_IF_IS_32BIT(T))
 	{ return __YAS_NETWORK_TO_LOCAL32(v); }
 	template<typename T>
-	static T bswap(const T &v, __YAS_ENABLE_IF_IS_ANY_OF(T, std::int64_t, std::uint64_t))
+	static T bswap(const T &v, __YAS_ENABLE_IF_IS_64BIT(T))
 	{ return __YAS_NETWORK_TO_LOCAL64(v); }
 
 	template<typename T>

--- a/include/yas/detail/type_traits/type_traits.hpp
+++ b/include/yas/detail/type_traits/type_traits.hpp
@@ -103,6 +103,89 @@ struct disable_if_is_any_of
 
 /***************************************************************************/
 
+template<typename T>
+struct is_signed_integer: std::integral_constant<
+    bool
+    , std::is_signed<T>::value
+    && std::is_integral<T>::value
+    && std::is_same<T, char>::value == false
+    && std::is_same<T, signed char>::value == false
+
+>
+{};
+
+template<typename T>
+struct is_unsigned_integer: std::integral_constant<
+    bool
+    , std::is_unsigned<T>::value
+    && std::is_integral<T>::value
+    && std::is_same<T, unsigned char>::value == false
+    && std::is_same<T, bool>::value == false
+>
+{};
+
+template<typename T>
+struct enable_if_is_signed_integer
+    :std::enable_if<is_signed_integer<T>::value>
+{};
+
+template<typename T>
+struct enable_if_is_unsigned_integer
+    :std::enable_if<is_unsigned_integer<T>::value>
+{};
+
+#define __YAS_ENABLE_IF_IS_SIGNED_INTEGER(T) \
+    typename ::yas::detail::enable_if_is_signed_integer<T>::type* = 0
+
+#define __YAS_ENABLE_IF_IS_UNSIGNED_INTEGER(T) \
+    typename ::yas::detail::enable_if_is_unsigned_integer<T>::type* = 0
+
+/***************************************************************************/
+
+template<typename T>
+struct is_16bit: std::integral_constant<
+    bool, sizeof(T) == 2
+>
+{};
+
+template<typename T>
+struct is_32bit: std::integral_constant<
+    bool, sizeof(T) == 4
+>
+{};
+
+template<typename T>
+struct is_64bit: std::integral_constant<
+    bool, sizeof(T) == 8
+>
+{};
+
+template<typename T>
+struct enable_if_is_16bit
+    :std::enable_if<is_16bit<T>::value>
+{};
+
+template<typename T>
+struct enable_if_is_32bit
+    :std::enable_if<is_32bit<T>::value>
+{};
+
+template<typename T>
+struct enable_if_is_64bit
+    :std::enable_if<is_64bit<T>::value>
+{};
+
+#define __YAS_ENABLE_IF_IS_16BIT(T) \
+    typename ::yas::detail::enable_if_is_16bit<T>::type* = 0
+
+#define __YAS_ENABLE_IF_IS_32BIT(T) \
+    typename ::yas::detail::enable_if_is_32bit<T>::type* = 0
+
+#define __YAS_ENABLE_IF_IS_64BIT(T) \
+    typename ::yas::detail::enable_if_is_64bit<T>::type* = 0
+
+/***************************************************************************/
+
 enum class type_prop {
      is_enum
     ,is_fundamental


### PR DESCRIPTION
The byte swapping, storage size calculation and write and read of signed and unsigned integers has been streamlined.

Hi!

Benchmark results for my changes are:

Old code base:
```
* TEST: yas
* name       : general
* info       : use yas::mem_<io>stream as buffer
* data size  : 10463
* serialize  : 2132
* deserialize: 4650

* TEST: yas
* name       : compression
* info       : with yas::no_header and yas::compacted
* data size  : 7315
* serialize  : 2506
* deserialize: 5087

* TEST: yas
* name       : stream
* info       : using std::stringstream
* data size  : 10463
* serialize  : 9641
* deserialize: 11969
```

New code base:
```
* TEST: yas
* name       : general
* info       : use yas::mem_<io>stream as buffer
* data size  : 10463
* serialize  : 2143
* deserialize: 4674

* TEST: yas
* name       : compression
* info       : with yas::no_header and yas::compacted
* data size  : 7315
* serialize  : 2502
* deserialize: 4998

* TEST: yas
* name       : stream
* info       : using std::stringstream
* data size  : 10463
* serialize  : 9519
* deserialize: 11757
```