### PR TITLE
Add emscripten support

### DIFF
--- a/include/yas/detail/config/endian.hpp
+++ b/include/yas/detail/config/endian.hpp
@@ -38,7 +38,7 @@
 
 /***************************************************************************/
 
-#if defined(__linux__) || defined(__ANDROID__)
+#if defined(__linux__) || defined(__ANDROID__) || defined(__EMSCRIPTEN__)
 #   include <endian.h>
 #   if (__BYTE_ORDER == __LITTLE_ENDIAN)
 #       define __YAS_LITTLE_ENDIAN (1)

--- a/include/yas/detail/io/json_streams.hpp
+++ b/include/yas/detail/io/json_streams.hpp
@@ -103,7 +103,7 @@ struct json_ostream {
 
 	// for unsigned 16/32/64 bits
 	template<typename T>
-	void write(const T &v, __YAS_ENABLE_IF_IS_ANY_OF(T, std::uint16_t, std::uint32_t, std::uint64_t)) {
+	void write(const T &v, __YAS_ENABLE_IF_IS_ANY_OF(T, std::uint16_t, std::uint32_t, std::uint64_t, std::size_t)) {
 		char buf[sizeof(v)*4];
 		std::size_t len = Trait::utoa(buf, sizeof(buf), v);
 
@@ -204,7 +204,7 @@ struct json_istream {
 
 	// for unsigned 16/32/64 bits
 	template<typename T>
-	void read(T &v, __YAS_ENABLE_IF_IS_ANY_OF(T, std::uint16_t, std::uint32_t, std::uint64_t)) {
+	void read(T &v, __YAS_ENABLE_IF_IS_ANY_OF(T, std::uint16_t, std::uint32_t, std::uint64_t, std::size_t)) {
 		char buf[sizeof(T)*4];
 		const std::size_t n = json_read_num(is, buf, sizeof(buf));
 

--- a/include/yas/detail/io/text_streams.hpp
+++ b/include/yas/detail/io/text_streams.hpp
@@ -93,7 +93,7 @@ struct text_ostream {
 
     // for unsigned 16/32/64 bits
     template<typename T>
-    void write(const T &v, __YAS_ENABLE_IF_IS_ANY_OF(T, std::uint16_t, std::uint32_t, std::uint64_t)) {
+    void write(const T &v, __YAS_ENABLE_IF_IS_ANY_OF(T, std::uint16_t, std::uint32_t, std::uint64_t, std::size_t)) {
         char buf[sizeof(v) * 4];
         std::size_t len = Trait::utoa(buf + 1, sizeof(buf), v);
 
@@ -192,7 +192,7 @@ struct text_istream {
 
     // for unsigned 16/32/64 bits
     template<typename T>
-    void read(T &v, __YAS_ENABLE_IF_IS_ANY_OF(T, std::uint16_t, std::uint32_t, std::uint64_t)) {
+    void read(T &v, __YAS_ENABLE_IF_IS_ANY_OF(T, std::uint16_t, std::uint32_t, std::uint64_t, std::size_t)) {
         char buf[sizeof(T) * 4];
         std::uint8_t n;
 

--- a/include/yas/types/utility/autoarray.hpp
+++ b/include/yas/types/utility/autoarray.hpp
@@ -42,6 +42,8 @@
 #include <yas/detail/tools/cast.hpp>
 #include <yas/types/concepts/const_sized_array.hpp>
 
+#include <iterator>
+
 namespace yas {
 namespace detail {
 


### PR DESCRIPTION
I tried to compile this library with [emscripten](https://emscripten.org/) (currently clang 6.0.1) and got some problems.

endian.hpp - missing CPU type
-   [\_\_EMSCRIPTEN\_\_](https://emscripten.org/docs/compiling/Building-Projects.html#detecting-emscripten-in-preprocessor)
- "endian.h" exists in the sdk and contains [\_\_LITTLE\_ENDIAN](https://github.com/WebAssembly/design/blob/master/Portability.md#assumptions-for-efficient-execution)

autoarray.hpp - std::begin / std::end undefined
- add #include\<iterator\>, no idea why it is already defined with g++

json_streams.hpp/text_streams.hpp - [std::size = unsigned long != unsigned int](https://reviews.llvm.org/D40526)
- add std::size\_t to relevant \_\_YAS\_ENABLE\_IF\_IS\_ANY\_OF, which guarantees that it is recognized even if std::size\_t is neither std::uint_16_t, std::uint_32_t or std::uint_64_t

Example:
`em++ main.cpp -Iyas/include -std=c++17 -o index.html`

```cpp
#include <yas/serialize.hpp>
#include <yas/std_types.hpp>
#include <yas/types/std/string.hpp>
#include <iostream>

int main() {
    std::string c = "test", cc;
    constexpr std::size_t flags = yas::mem|yas::json;
    auto buf = yas::save<flags>(YAS_OBJECT("myobject", c));
    yas::load<flags>(buf, YAS_OBJECT_NVP("myobject", ("c", cc)));
    std::cout << "cc:" << std::endl;
    std::cout << cc << std::endl;
}
```