### PR TITLE
fix compilation on FreeBSD

### DIFF
--- a/include/yas/detail/config/endian.hpp
+++ b/include/yas/detail/config/endian.hpp
@@ -51,6 +51,17 @@
 #   else
 #       error Unknown machine endianness detected.
 #   endif
+#elif defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+#   include <sys/endian.h>
+#   if (_BYTE_ORDER == _LITTLE_ENDIAN)
+#       define __YAS_LITTLE_ENDIAN (1)
+#       define __YAS_BIG_ENDIAN (0)
+#   elif (_BYTE_ORDER == _BIG_ENDIAN)
+#       define __YAS_LITTLE_ENDIAN (0)
+#       define __YAS_BIG_ENDIAN (1)
+#   else
+#       error Unknown machine endianness detected.
+#   endif
 #elif defined(_BIG_ENDIAN)
 #   define __YAS_LITTLE_ENDIAN (0)
 #   define __YAS_BIG_ENDIAN (1)


### PR DESCRIPTION
On __FreeBSD__, the logic seems to work the same as on __linux__, just with one underscore removed. So _BIG_ENDIAN was defined, and yas decided that it has to compile for a big endian system. But compilation on big endian seems to be broken, so I noticed the problem.
