### PR TITLE
Updated Tests - Changed abseil version 20200923.2

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,7 +20,7 @@ install:
   - ps: Write-Host "Checking for Boost 1.66.0 x64...";$boostdir = Test-Path $Env:BOOST_LIB64;If ($boostdir -eq $False) {Write-Host "Downloading Boost 1.66.0 x64...";$exePath = "$Env:TEMP\boost_1_66_0-msvc-14.1-64.exe";(New-Object Net.WebClient).DownloadFile('https://bintray.com/boostorg/release/download_file?file_path=1.66.0%2Fbinaries%2Fboost_1_66_0-msvc-14.1-64.exe', $exePath);Write-Host "Installing Boost 1.66.0 x64...";cmd /c start /wait "$exePath" /verysilent;del $exePath};Write-Host "Boost 1.66.0 x64 installed!" -ForegroundColor Green
 
 build_script:
-  - git clone https://github.com/abseil/abseil-cpp.git C:/abseil-cpp
+  - git clone --depth 1 --branch 20200923.2 https://github.com/abseil/abseil-cpp.git C:/abseil-cpp
   - dir "C:/local/boost_1_66_0"
   - cd ../yas/tests/base
   - echo Build for %platform%-%configuration%

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,9 @@ before_install:
   - wget http://sourceforge.net/projects/boost/files/boost/1.64.0/boost_1_64_0.tar.bz2
   - tar -jxf boost_1_64_0.tar.bz2
   - sudo cp -r boost_1_64_0/boost /usr/local/include
-  - echo $HOME/abseil-cpp
-  - git clone https://github.com/abseil/abseil-cpp.git $HOME/abseil-cpp
+  - wget https://github.com/abseil/abseil-cpp/archive/20200923.2.zip && unzip 20200923.2.zip && mv abseil-cpp-20200923.2 abseil-cpp
+  - export ABSEIL_HOME=`pwd`/abseil-cpp
+  - echo $ABSEIL_HOME
 
 install:
   - g++ -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
   - wget http://sourceforge.net/projects/boost/files/boost/1.64.0/boost_1_64_0.tar.bz2
   - tar -jxf boost_1_64_0.tar.bz2
   - sudo cp -r boost_1_64_0/boost /usr/local/include
-  - sudo git clone https://github.com/abseil/abseil-cpp.git /usr/local/abseil-cpp
+  - git clone https://github.com/abseil/abseil-cpp.git abseil-cpp
 
 install:
   - g++ -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,8 @@ before_install:
   - wget http://sourceforge.net/projects/boost/files/boost/1.64.0/boost_1_64_0.tar.bz2
   - tar -jxf boost_1_64_0.tar.bz2
   - sudo cp -r boost_1_64_0/boost /usr/local/include
-  - git clone https://github.com/abseil/abseil-cpp.git abseil-cpp
+  - echo $HOME/abseil-cpp
+  - git clone https://github.com/abseil/abseil-cpp.git $HOME/abseil-cpp
 
 install:
   - g++ -v

--- a/tests/base/CMakeLists.txt
+++ b/tests/base/CMakeLists.txt
@@ -24,7 +24,7 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
         add_definitions(-DYAS_SERIALIZE_ABSL_TYPES)
 
         # Process Abseil's CMake build system
-        add_subdirectory("$ENV{HOME}/abseil-cpp" "build/abseil")
+        add_subdirectory("$ENV{ABSEIL_HOME}" "build/abseil")
     endif()
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
@@ -39,7 +39,7 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
         add_definitions(-DYAS_SERIALIZE_ABSL_TYPES)
         
         # Process Abseil's CMake build system
-        add_subdirectory("$ENV{HOME}/abseil-cpp" "build/abseil")
+        add_subdirectory("$ENV{ABSEIL_HOME}" "build/abseil")
     endif()
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     if(CMAKE_SIZEOF_VOID_P EQUAL 8)

--- a/tests/base/CMakeLists.txt
+++ b/tests/base/CMakeLists.txt
@@ -24,7 +24,7 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
         add_definitions(-DYAS_SERIALIZE_ABSL_TYPES)
 
         # Process Abseil's CMake build system
-        add_subdirectory("/usr/local/abseil-cpp" "build/abseil")
+        add_subdirectory("$ENV{HOME}/abseil-cpp" "build/abseil")
     endif()
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
@@ -39,7 +39,7 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
         add_definitions(-DYAS_SERIALIZE_ABSL_TYPES)
         
         # Process Abseil's CMake build system
-        add_subdirectory("/usr/local/abseil-cpp" "build/abseil")
+        add_subdirectory("$ENV{HOME}/abseil-cpp" "build/abseil")
     endif()
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     if(CMAKE_SIZEOF_VOID_P EQUAL 8)


### PR DESCRIPTION
Apparently building the tests from the latest source at abseil's github was causing some issue with linux builds. It might actually cause problems in the future also if they introduce some major changes like requirement of linking additional libs, etc. So I changed the travis and appveyor builds to pull the latest (as of now) stable build which is 20200923.2. @niXman you should actually update the readme for people so that they know which version of abseil will actually work.