### PR TITLE
Fixed warnings that are considered an error

### DIFF
--- a/include/yas/buffers.hpp
+++ b/include/yas/buffers.hpp
@@ -115,10 +115,10 @@ struct shared_buffer {
         size = new_size;
     }
 
-    void assign(const void *ptr, std::size_t size) {
-        resize(size);
-        if ( size ) {
-            std::memcpy(data.get(), ptr, size);
+    void assign(const void *ptr, std::size_t new_size) {
+        resize(new_size);
+        if ( new_size ) {
+            std::memcpy(data.get(), ptr, new_size);
         }
     }
 

--- a/include/yas/detail/config/config.hpp
+++ b/include/yas/detail/config/config.hpp
@@ -54,7 +54,7 @@
 #   define __YAS_CONSTEXPR_IF(...) if constexpr ( static_cast<bool>(__VA_ARGS__) )
 #   define __YAS_FALLTHROUGH [[fallthrough]]
 #else
-#   define __YAS_CONSTEXPR_IF(...) if (__VA_ARGS__)
+#   define __YAS_CONSTEXPR_IF(...) if constexpr ( static_cast<bool>(__VA_ARGS__) )
 #endif
 
 /***************************************************************************/

--- a/include/yas/file_streams.hpp
+++ b/include/yas/file_streams.hpp
@@ -71,7 +71,7 @@ struct file_ostream {
         }
 
         const char *fmode = file_mode_str(m);
-        file = std::fopen(fname, fmode);
+        fopen_s(&file, fname, fmode);
         if ( !file ) {
             __YAS_THROW_ERROR_OPEN_FILE();
         }
@@ -102,7 +102,8 @@ private:
         __YAS_THROW_BAD_FILE_MODE();
     }
     static bool file_exists(const char *fname) {
-        std::FILE* file = std::fopen(fname, "r");
+        std::FILE* file;
+        fopen_s(&file, fname, "r");
         if ( file ) {
             std::fclose(file);
 
@@ -121,8 +122,8 @@ struct file_istream {
     YAS_MOVABLE(file_istream)
 
     file_istream(const char *fname, std::size_t m = 0)
-        :file(std::fopen(fname, "rb"))
     {
+        fopen_s(&file, fname, "rb");
         if ( !file ) {
             __YAS_THROW_ERROR_OPEN_FILE();
         }

--- a/include/yas/types/std/string.hpp
+++ b/include/yas/types/std/string.hpp
@@ -58,7 +58,7 @@ struct serializer<
 > {
     template<typename Archive>
     static Archive& save(Archive& ar, const std::string &str) {
-        if ( F & yas::json ) {
+        if constexpr ( F & yas::json ) {
             if ( str.empty() ) {
                 ar.write("null", 4);
             } else {
@@ -76,7 +76,7 @@ struct serializer<
 
     template<typename Archive>
     static Archive& load(Archive& ar, std::string &str) {
-        if ( F & yas::json ) {
+        if constexpr ( F & yas::json ) {
             char ch = ar.getch();
             if ( ch == '\"' ) {
                 load_string(str, ar);


### PR DESCRIPTION
When using the MSVC2019 (c++17) compiler with "Handle Exceptions as Errors" enabled and exception level 4 (WX4), I had the following exceptions that were treated as errors:
4996, -Wdeprecated-declarations 	         - 'fopen': This function or variable may be unsafe
4458, -Wmissing-variable-declarations   - declaration hides class member
4127, -Wtype-limits				 - conditional expression is constant