### PR TITLE
Fix segfault when reading from empty buffer

### DIFF
--- a/include/yas/detail/io/json_streams.hpp
+++ b/include/yas/detail/io/json_streams.hpp
@@ -208,6 +208,8 @@ struct json_istream {
 	void read(T &v, __YAS_ENABLE_IF_IS_ANY_OF(T, std::int16_t, std::int32_t, std::int64_t)) {
 		char buf[sizeof(T)*4];
 		const std::size_t n = json_read_num(is, buf, sizeof(buf));
+		__YAS_THROW_READ_ERROR(n == 0);
+
 		v = Trait::template atoi<T>(buf, n);
 	}
 
@@ -216,6 +218,7 @@ struct json_istream {
 	void read(T &v, __YAS_ENABLE_IF_IS_ANY_OF(T, std::uint16_t, std::uint32_t, std::uint64_t)) {
 		char buf[sizeof(T)*4];
 		const std::size_t n = json_read_num(is, buf, sizeof(buf));
+		__YAS_THROW_READ_ERROR(n == 0);
 
 		v = Trait::template atou<T>(buf, n);
 	}
@@ -230,6 +233,7 @@ struct json_istream {
 		}
 
 		const std::size_t n = json_read_double(is, buf, sizeof(buf));
+		__YAS_THROW_READ_ERROR(n == 0);
 
 		if ( is.peekch() == '\"' ) {
 			is.getch();
@@ -248,6 +252,7 @@ struct json_istream {
 		}
 
 		const std::size_t n = json_read_double(is, buf, sizeof(buf));
+		__YAS_THROW_READ_ERROR(n == 0);
 
 		if ( is.peekch() == '\"' ) {
 			is.getch();

--- a/include/yas/mem_streams.hpp
+++ b/include/yas/mem_streams.hpp
@@ -159,9 +159,13 @@ struct mem_istream {
     }
 
     bool empty() const { return cur == end; }
-    char peekch() const { return *cur; }
-    char getch() { return *cur++; }
-    void ungetch(char) { --cur; }
+    char peekch() const { return empty() ? EOF : *cur; }
+    char getch() { return empty() ? EOF : *cur++; }
+    void ungetch(char) {
+        if ( cur != beg ) {
+            --cur;
+        }
+    }
 
     shared_buffer get_shared_buffer() const { return shared_buffer(cur, __YAS_SCAST(std::size_t, end-cur)); }
     intrusive_buffer get_intrusive_buffer() const { return intrusive_buffer(cur, __YAS_SCAST(std::size_t, end-cur)); }


### PR DESCRIPTION
Fixes

```c++
#include <yas/serialize.hpp>

int main() {
    try {
        int obj;

        yas::intrusive_buffer buf(nullptr, 0);
        yas::load<yas::mem | yas::json>(buf, obj);
    } catch (...) {}

    return 0;
}
```