### PR TITLE
Add support for std::monostate

### DIFF
--- a/include/yas/types/std/variant.hpp
+++ b/include/yas/types/std/variant.hpp
@@ -144,22 +144,50 @@ struct serializer<
             __YAS_CONSTEXPR_IF ( !(F & yas::compacted) ) {
                 json_skipws(ar);
             }
-            __YAS_THROW_IF_BAD_JSON_CHARS(ar, "[");
+            __YAS_THROW_IF_WRONG_JSON_CHARS(ar, "[");
             std::size_t idx = 0;
             ar & YAS_OBJECT(nullptr, idx);
             __YAS_CONSTEXPR_IF ( !(F & yas::compacted) ) {
                 json_skipws(ar);
             }
-            __YAS_THROW_IF_BAD_JSON_CHARS(ar, ",");
+            __YAS_THROW_IF_WRONG_JSON_CHARS(ar, ",");
             std_variant_switch<F>(ar, idx, v);
             __YAS_CONSTEXPR_IF ( !(F & yas::compacted) ) {
                 json_skipws(ar);
             }
-            __YAS_THROW_IF_BAD_JSON_CHARS(ar, "]");
+            __YAS_THROW_IF_WRONG_JSON_CHARS(ar, "]");
         } else {
             std::uint8_t idx = 0;
             ar & idx;
             std_variant_switch<F>(ar, idx, v);
+        }
+
+        return ar;
+    }
+};
+
+/***************************************************************************/
+
+template<std::size_t F>
+struct serializer<
+     type_prop::not_a_fundamental
+    ,ser_case::use_internal_serializer
+    ,F
+    ,std::monostate
+> {
+    template<typename Archive>
+    static Archive& save(Archive& ar, const std::monostate &) {
+        __YAS_CONSTEXPR_IF ( F & yas::json ) {
+            ar.write("null", 4);
+        }
+
+        return ar;
+    }
+
+    template<typename Archive>
+    static Archive& load(Archive& ar, std::monostate &) {
+        __YAS_CONSTEXPR_IF ( F & yas::json ) {
+            __YAS_THROW_IF_WRONG_JSON_CHARS(ar, "null");
         }
 
         return ar;

--- a/tests/base/include/variant.hpp
+++ b/tests/base/include/variant.hpp
@@ -90,6 +90,21 @@ bool variant_test(std::ostream &log, const char *archive_type, const char *test_
             return false;
         }
     }
+    {
+        std::variant<std::monostate, int> v0, v1(4);
+
+        typename archive_traits::oarchive oa;
+        archive_traits::ocreate(oa, archive_type);
+        oa & YAS_OBJECT_NVP("obj", ("variant", v0));
+
+        typename archive_traits::iarchive ia;
+        archive_traits::icreate(ia, oa, archive_type);
+        ia & YAS_OBJECT_NVP("obj", ("variant", v1));
+        if ( !(v0 == v1) ) {
+            YAS_TEST_REPORT(log, archive_type, test_name);
+            return false;
+        }
+    }
 #endif // __cplusplus >= 201703L
 
     return true;


### PR DESCRIPTION
Allows serialization of `std::monostate` type which is used together with `std::variant`.