### PR TITLE
Fix mishandling of empty objects in json_skip_object().

### DIFF
--- a/include/yas/detail/tools/json_tools.hpp
+++ b/include/yas/detail/tools/json_tools.hpp
@@ -179,6 +179,8 @@ template<typename Archive>
 void json_skip_object(Archive &ar) {
     while ( true ) {
         json_skipws(ar);
+        if ( ch == '}' ) break;
+
         __YAS_THROW_IF_WRONG_JSON_CHARS(ar, "\"")
 
         json_skip_string(ar); // key


### PR DESCRIPTION
Fixes #115.