### PR TITLE
Allow `final` structs & classes serialization

### DIFF
--- a/tests/base/include/json_conformance.hpp
+++ b/tests/base/include/json_conformance.hpp
@@ -49,7 +49,7 @@
 
 /***************************************************************************/
 
-struct canada_t {
+struct canada_t final {
     canada_t() = default;
 
     std::string type;


### PR DESCRIPTION
Hi,

I can't serialize a class `T` marked as `final` because the `detail::has_memfn_serializer<>` metafunction relies on the following trick to detect the serialize function presence.

```
struct derived: T {
        using T::serialize;
        no serialize(...) const;
};
```

I've updated the `tests/base/include/json_conformance.hpp` to add `final` to the tested class in order to experience the limitation.

This MR provides another implementation of the `detail::has_memfn_serializer<>` metafunction, but it ignores the return type of the `T::serialize() `function. I'm not comfortable with this choice because in your implementation, my understanding is that you ignore the return type as well, but it seems there is some facility to check it (i.e. `return_value_check`)  ¯\_(ツ)_/¯.

Some tests are failing as well on my Fedora 39, and there are warnings.

Do you want me to do some cleaning ?